### PR TITLE
activating metadata publish route

### DIFF
--- a/lib/middleware/containers.js
+++ b/lib/middleware/containers.js
@@ -26,15 +26,15 @@ var containers = module.exports = createModelMiddleware(Container, {
     series(
       images.findById('container.parent', { name: 1, description: 1, tags: 1, last_write: 1 }),
       ternary(containers.metaPublishCheck('image'), // middleware check
-        containers.model.metaPublish('image'), // model call
-        containers.fullPublish))(req, res, next);
+        containers.model.metaPublish('image'),
+        containers.fullPublish),
+      body.unset('status'))(req, res, next);
   },
   fullPublish: function (req, res, next) {
     series(
       dockworker.runBuildCmd,
       body.trim('status'),
       containers.model.atomicUpdateCommitStatusAndName('body', 'me'),
-      body.unset('status'), // to prevent nonatomic set below
       ternary(containers.checkFound, // atomic update uses findAndModify
         harbourmaster.commitContainer, // container updated successfull
         containers.findById('params.containerId', { files: 0 })))(req, res, next);

--- a/lib/models/containers.js
+++ b/lib/models/containers.js
@@ -276,14 +276,13 @@ ContainerSchema.methods.metaPublishCheck = function (image) {
   if (!this.last_write || !image.last_write) {
     return false;
   }
-  if (this.status !== 'Draft' || this.commit_error === '') {
+  if (this.status !== 'Draft' && this.commit_error === '') {
     return false;
   }
-  return false; // this.last_write - image.last_write === 0; TODO: uncomment
+  return this.last_write - image.last_write === 0;
 };
 
 ContainerSchema.methods.metaPublish = function (parent /* image */, cb) {
-  // TODO: meta publish still needs to cause redirect
   // sanity
   var container = this;
   if (container.last_write - parent.last_write !== 0) {
@@ -301,8 +300,13 @@ ContainerSchema.methods.metaPublish = function (parent /* image */, cb) {
     'status': 'Finished',
     'child': parent._id.toString()
   });
-
-  cb(null, this);
+  var self = this;
+  async.parallel([
+    parent.save.bind(parent),
+    self.save.bind(self)
+  ], function (err, results) {
+    cb(err, self);
+  });
 };
 
 ContainerSchema.methods.inheritFromImage = function (image, cb) {

--- a/test/containers.js
+++ b/test/containers.js
@@ -2,6 +2,7 @@ var _ = require('lodash');
 var users = require('./lib/userFactory');
 var images = require('./lib/imageFactory');
 var helpers = require('./lib/helpers');
+var spy = require('./lib/spy');
 var extendContext = helpers.extendContext;
 var extendContextSeries = helpers.extendContextSeries;
 var uuid = require('node-uuid');
@@ -382,15 +383,24 @@ describe('Containers', function () {
             newContainer: ['admin.createContainer', ['publish._id']]
           }));
           it ('should update the container', function (done) {
+            var checkDone = helpers.createCheckDone(done);
+            var Container = require('models/containers');
+            spy.classMethod(Container, 'metaPublish', checkDone.done());
             this.admin.specRequest(this.newContainer._id)
               .send({ status: 'Committing back', name: 'project AWESOME' })
               .expect(200)
-              .end(done);
+              .end(checkDone.done());
           });
         });
         describe('already committing', function () {
           var commitStatus = 'Committing new';
+          var fileData = {
+            name: 'filename.txt',
+            path: '/',
+            content: 'file content'
+          };
           beforeEach(extendContextSeries({
+            file: ['owner.containerCreateFile', ['container._id', fileData]],
             commit: ['owner.patchContainer', ['container._id', {
               body: { status: commitStatus, name: 'new name' },
               expect: 200

--- a/test/lib/spy.js
+++ b/test/lib/spy.js
@@ -1,0 +1,20 @@
+module.exports.func = function (fn, ctx, cb) {
+  cb = Array.prototype.slice.call(arguments).pop();
+  if (cb === ctx) {
+    ctx = null;
+  }
+  return function () {
+    fn.apply(ctx, arguments);
+    cb(); // callback to confirm the function was invoked
+  };
+};
+
+module.exports.classMethod = function (Class, method, cb) {
+  var self = this;
+  var origMethod = Class.prototype[method];
+  var proxy = function () {
+    origMethod.apply(this, arguments);
+    cb(); // callback to confirm the function was invoked
+  };
+  Class.prototype[method] = proxy;
+};


### PR DESCRIPTION
For PC-7, re-activating the metadata publish route with some new tests and fixes
- Save the container, fix the test, fix the metapublish path
- adding spy helper
- fixing condition for doing meta publish
- fixing tests to check for meta publish
