### PR TITLE
Adding CD to build command

### DIFF
--- a/lib/middleware/dockworker.js
+++ b/lib/middleware/dockworker.js
@@ -41,7 +41,7 @@ module.exports = {
     }
     Dockworker.runCommand({
       servicesToken: container.servicesToken,
-      command: 'bash -c "' + container.build_cmd + '"'
+      command: 'bash -c "cd $RUNNABLE_USER_DIR && ' + container.build_cmd + '"'
     }, function(err, res, body) {
       if(err || res.statusCode !== 200) {
         err.stderr = err.msg;


### PR DESCRIPTION
`bash` starts in `/`, we need build commands to be run in the user directory

@anandkumarpatel @tjmehta 
