### PR TITLE
Only copy parent when _id is not the container's parent already

### DIFF
--- a/lib/models/images.js
+++ b/lib/models/images.js
@@ -175,8 +175,8 @@ ImageSchema.methods.inheritFromContainer = function (container, cb) {
     'specification',
     'last_write'
   ];
-  if (this._id !== container.parent) {
-    attributes.push('parent');
+  if (!utils.equalObjectIds(this._id, container.parent)) {
+    attributes.push('parent'); // don't inherit parent if parent is self (publish back)
   }
   if (container.toJSON) {
     container = container.toJSON();


### PR DESCRIPTION
prevents images being parents of themselves... ew...
